### PR TITLE
Change the frame dragging duplication status based on whether ctrl or…

### DIFF
--- a/src/helpers/editor.ts
+++ b/src/helpers/editor.ts
@@ -952,6 +952,14 @@ const bodyMouseMoveEventHandlerForFrameDnD = (mouseEvent: MouseEvent): void => {
             (vm.$refs[getCaretUID(newCaretDropPosCaretPos, newCaretDropPosFrameId)] as InstanceType<typeof CaretContainer>).areDropFramesAllowed = 
                 isFrameDropAllowed(newCaretDropPosFrameId, newCaretDropPosCaretPos);
         }
+
+        // Update the duplicate status based on whether they are holding ctrl/alt:
+        if (mouseEvent.ctrlKey || mouseEvent.altKey) {
+            addDuplicateActionOnFramesDnD();
+        }
+        else {
+            removeDuplicateActionOnFramesDnD();
+        }
     }
 };
 


### PR DESCRIPTION
… alt is held in the mousemove event that might move the drop destination frame cursor.  This fixes an issue where on Mac, keydown is only fired once and thus doesn't repeatedly set the status (compared to Windows, which repeatedly fires keydown events).